### PR TITLE
Remove "load" Event Listener

### DIFF
--- a/spec/grading.spec.js
+++ b/spec/grading.spec.js
@@ -26,9 +26,7 @@ describe ("Grading Tests: ", function () {
       stylesElement.textContent = css;
       window.document.head.appendChild(stylesElement);
 
-      window.addEventListener("load", function() {
-         container = window.document;
-      });
+      container = window.document;
    });
 
    it("HTML includes the correct number of certain elements", function() {


### PR DESCRIPTION
Hello folks. I had a student complete assignment 4, submitted it to github classroom, but received an error response from the grading. The student had everything right. Each of the seven tests were stating that container was undefined . I did one quick check and noticed that some tests shouldn’t be erroring, so I investigated.

inside the spec directory of each student’s assignment repo, there’s a file called grading.spec.js that runs and validates the repo. Inside the file, there’s a beforeAll function with this:
```javascript
beforeAll(function() {

      const dom = new JSDOM(html, options);
      window = dom.window;

      let stylesElement = window.document.createElement("style");
      stylesElement.textContent = css;
      window.document.head.appendChild(stylesElement);

      window.addEventListener("load", function() {
          container = window.document;
      });
   });
```
Everything seems fine at first until you reach this line:

```javascript
window.addEventListener("load", function() {
    container = window.document;
});
```
Since we loaded the html using JSDOM and saved it to a variable, the load event we are listening for never fires and the container variable is never set. Each test uses the container variable to check for id names, class names, and even the html entities in the document.

The Fix:
If the student is complaining that they have everything correct but the grader is still failing, check this file, and if it looks like above, move the container variable outside of the event listener so the tests have a defined variable.

I just walked a student through this step and we were able to get her branch to pass. This is her branch:
https://github.com/LC101-September-2021/assignment-4-html-me-something-cristinagratton